### PR TITLE
Add example alias step to workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ action "alias" {
 }
 ```
 
+For more examples, visit: [actions/example-zeit-now](https://github.com/actions/example-zeit-now).
+
 ### Secrets
 
 * `ZEIT_TOKEN` - **Required**. The token to use for authentication with the Zeit Now API ([more info](https://zeit.co/blog/introducing-api-tokens-management))

--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ The GitHub Deployer for [Zeit](https://zeit.co/) task wraps the [Now CLI](https:
 ```
 workflow "Deploy on Now" {
   on = "push"
-  resolves = ["deploy"]
+  resolves = ["alias"]
 }
 
 action "deploy" {
   uses = "actions/zeit-now@master"
+  secrets = [
+    "ZEIT_TOKEN",
+  ]
+}
+
+action "alias" {
+  needs = ["deploy"]
+  uses = "actions/zeit-now@master"
+  args = "alias"
   secrets = [
     "ZEIT_TOKEN",
   ]


### PR DESCRIPTION
Adding another Action to the documentation to show how this can be used with commands beyond deploying.

cc @bkeepers @nickvanw 