### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ workflow "Deploy on Now" {
 
 action "deploy" {
   uses = "actions/zeit-now@master"
+  args = "--public --no-clipboard deploy ./site > $HOME/deploy.txt"
   secrets = [
     "ZEIT_TOKEN",
   ]
@@ -20,7 +21,7 @@ action "deploy" {
 action "alias" {
   needs = ["deploy"]
   uses = "actions/zeit-now@master"
-  args = "alias"
+  args = "alias `cat /github/home/deploy.txt`"
   secrets = [
     "ZEIT_TOKEN",
   ]


### PR DESCRIPTION
It's best practice to persist the deploy URL between commands.

Fixes https://github.com/actions/zeit-now/issues/3

I'll open a separate issue for us to make this action easier to use.